### PR TITLE
* Fixed unique compare length in prefetch_queue(). 

### DIFF
--- a/src/dgate/src/dgate.cpp
+++ b/src/dgate/src/dgate.cpp
@@ -12449,7 +12449,7 @@ BOOL prefetch_queue(const char *operation, int N, char *patientid, const char *s
   { strncpy(data+100, studyuid,  64);
     strncpy(data+165, seriesuid, 64);
     strncpy(data+230, server,   360);
-    return into_queue_unique(q[N+1], data, 490);
+    return into_queue_unique(q[N+1], data, 590);
   }
   else
   { strncpy(data+82,  server,    17);


### PR DESCRIPTION
Hello Marcel, 

First of all thanks for your continued work on Conquest Dicom. 

I think I found a typo in a mem compare in dgate.cpp::prefetch_queue() where compare length is 490 but should be 590.

Thanks and greetings, 

Martijn 