### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+ConQuest DICOM Server
+
+Copyright (c) 2025 University of Manchester.
+Developed by Marcel van Herk, Lambert Zijp and Jan Meinders; the Netherlands
+Cancer Institute; Radiotherapy Department; maintained by Marcel van Herk,
+University of Manchester.
+
+Copyright (c) 1995 Regents of the University of California.  All rights
+reserved.
+Developed by: Mark Oskin, mhoskin@ucdavis.edu; University of California, Davis
+Medical Center; Department of Radiology with a Solaris port done and maintained
+by: Terry Rosenbaum; Michigan State University; Department of Radiology.
+
+Redistribution and use in source and binary forms are permitted provided that
+the above copyright notice and this paragraph are duplicated in all such forms
+and that any documentation, advertising materials, and other materials related
+to such distribution and use acknowledge that the software was developed by the
+University of California, Davis.  The name of the University may not be used to
+endorse or promote  products derived from this software without specific prior
+written permission.  THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
Adds the LICENSE file we discussed in our conversation.

The text is copied verbatim from dicom.html — the same three paragraphs, with only the line
wrapping changed, since the source has each paragraph on a single line. Nothing is reworded,
and I checked that mechanically rather than by eye.

I have deliberately left the original spelling as it stands, including "MERCHANTIBILITY" and
the ``AS IS'' quoting. It is not my text to correct, and a licence is not something to edit
quietly. Say the word if you would like either tidied up and I will amend the PR.

The first line naming the server sits outside the licence text and can go if you would rather
have a bare file.

Placing it in the repository root means GitHub will display the licence on the repository page,
and it is understood to cover the repository as a whole — the dgate sources, the Lua scripts and
the web files alike, which matches what you said about the server having grown since the text
was written. If you intend a narrower scope for any part of the tree, tell me and I will adjust
it before you merge.

I can also add a NOTICE file listing the open source components already acknowledged in the
README, kept separate from the licence itself — say the word and I will push it to this branch.